### PR TITLE
feat:Remove convai chars per minute from SubscriptionExtrasResponseModel

### DIFF
--- a/src/libs/ElevenLabs/Generated/ElevenLabs.Models.SubscriptionExtrasResponseModel.g.cs
+++ b/src/libs/ElevenLabs/Generated/ElevenLabs.Models.SubscriptionExtrasResponseModel.g.cs
@@ -23,13 +23,13 @@ namespace ElevenLabs
         public required int ConvaiConcurrency { get; set; }
 
         /// <summary>
-        /// The Convai characters per minute of the user.
+        /// The Convai characters per minute of the user. This field is deprecated and will always return None.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("convai_chars_per_minute")]
         public int? ConvaiCharsPerMinute { get; set; }
 
         /// <summary>
-        /// The Convai ASR characters per minute of the user.
+        /// The Convai ASR characters per minute of the user. This field is deprecated and will always return None.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("convai_asr_chars_per_minute")]
         public int? ConvaiAsrCharsPerMinute { get; set; }
@@ -96,10 +96,10 @@ namespace ElevenLabs
         /// The Convai concurrency of the user.
         /// </param>
         /// <param name="convaiCharsPerMinute">
-        /// The Convai characters per minute of the user.
+        /// The Convai characters per minute of the user. This field is deprecated and will always return None.
         /// </param>
         /// <param name="convaiAsrCharsPerMinute">
-        /// The Convai ASR characters per minute of the user.
+        /// The Convai ASR characters per minute of the user. This field is deprecated and will always return None.
         /// </param>
         /// <param name="forceLoggingDisabled">
         /// Whether the user's logging is disabled.

--- a/src/libs/ElevenLabs/openapi.yaml
+++ b/src/libs/ElevenLabs/openapi.yaml
@@ -22192,12 +22192,12 @@ components:
         convai_chars_per_minute:
           title: Convai Chars Per Minute
           type: integer
-          description: The Convai characters per minute of the user.
+          description: The Convai characters per minute of the user. This field is deprecated and will always return None.
           nullable: true
         convai_asr_chars_per_minute:
           title: Convai Asr Chars Per Minute
           type: integer
-          description: The Convai ASR characters per minute of the user.
+          description: The Convai ASR characters per minute of the user. This field is deprecated and will always return None.
           nullable: true
         force_logging_disabled:
           title: Force Logging Disabled
@@ -22229,8 +22229,6 @@ components:
         can_bypass_voice_captcha: true
         can_request_manual_pro_voice_verification: true
         concurrency: 10
-        convai_asr_chars_per_minute: 1000
-        convai_chars_per_minute: 1000
         convai_concurrency: 10
         force_logging_disabled: false
         moderation:
@@ -23489,8 +23487,6 @@ components:
           can_bypass_voice_captcha: true
           can_request_manual_pro_voice_verification: true
           concurrency: 10
-          convai_asr_chars_per_minute: 1000
-          convai_chars_per_minute: 1000
           convai_concurrency: 10
           force_logging_disabled: false
           moderation:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Marked convai_chars_per_minute and convai_asr_chars_per_minute as deprecated in the API, noting they will always return null.
- Chores
  - Removed previous default values for these deprecated fields from the schema.
  - No impact to other subscription fields or service behavior; existing integrations should stop relying on these metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->